### PR TITLE
Add most recent versions and DTLS support

### DIFF
--- a/images/baseimage/build-base-image.sh
+++ b/images/baseimage/build-base-image.sh
@@ -3,6 +3,7 @@ cd "$(dirname "$0")" || exit 1
 source ../helper-functions.sh
 
 # https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases
+_docker build --build-arg VERSION=3.19 --no-cache -t alpine-build:3.19 .
 _docker build --build-arg VERSION=3.12 --no-cache -t alpine-build:3.12 .
 #_docker build --build-arg VERSION=3.11 -t alpine-build:3.11 .
 #_docker build --build-arg VERSION=3.10 -t alpine-build:3.10 .

--- a/images/botan/Dockerfile-3x-dtls
+++ b/images/botan/Dockerfile-3x-dtls
@@ -1,0 +1,31 @@
+FROM alpine-build:3.19 as botan-base1
+ARG VERSION
+RUN wget https://botan.randombit.net/releases/Botan-3.${VERSION}.tar.xz
+RUN tar -xf Botan-3.${VERSION}.tar.xz
+WORKDIR Botan-3.${VERSION}
+RUN apk add python3
+RUN ./configure.py --prefix=/build/ &&\
+  make &&\
+  make install
+
+FROM entrypoint as botan-base2
+COPY --from=botan-base1 /lib/ld-musl-x86_64.so.1 \
+  /usr/lib/libstdc++.so.6 \
+  /usr/lib/libgcc_s.so.1 \
+  /build/lib/libbotan* /lib/
+COPY --from=botan-base1 /build/bin/botan /bin/
+ADD https://raw.githubusercontent.com/randombit/botan/master/src/tests/data/tls-policy/datagram.txt /datagram.txt
+
+FROM botan-base2 as botan-server
+ARG VERSION
+LABEL "tls_implementation"="botan"
+LABEL "tls_implementation_version"="3.${VERSION}"
+LABEL "tls_implementation_connectionRole"="server"
+ENTRYPOINT ["server-entrypoint", "botan", "tls_server"]
+
+FROM botan-base2 as botan-client
+ARG VERSION
+LABEL "tls_implementation"="botan"
+LABEL "tls_implementation_version"="3.${VERSION}"
+LABEL "tls_implementation_connectionRole"="client"
+ENTRYPOINT ["client-entrypoint", "botan", "tls_client"]

--- a/images/botan/datagram.txt
+++ b/images/botan/datagram.txt
@@ -1,0 +1,7 @@
+allow_dtls12 = true
+allowed_ciphers = AES-128 AES-256 AES-256/GCM AES-128/GCM
+allowed_macs = AEAD SHA-512 SHA-384 SHA-256 SHA-1
+allowed_key_exchange_methods = ECDH DH RSA
+allowed_signature_hashes = SHA-512 SHA-384 SHA-256 SHA-1
+allowed_signature_methods = ECDSA RSA
+request_client_certificate_authentication = false

--- a/images/botan/readme
+++ b/images/botan/readme
@@ -9,9 +9,10 @@ BOTAN
 	2.0.0, 2.0.1, 
 	2.1.0, 
 	2.2.0, 
-	2.3.0
-- server successfully tested: 1.11.6, 1.11.13, 1.11.33, 1.11.34, 1.11.29, 2.0.0, 2.1.0, 2.2.0, 2.3.0
-- clients successfully tested: 1.11.33, 1.11.34, 1.11.29, 2.0.0, 2.1.0, 2.2.0, 2.3.0
+	2.3.0,
+	3.2.0
+- server successfully tested: 1.11.6, 1.11.13, 1.11.33, 1.11.34, 1.11.29, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 3.2.0
+- clients successfully tested: 1.11.33, 1.11.34, 1.11.29, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 3.2.0
 - server and client versions failed to build (have to check build process): 1.11.8-1.11.13
 - clients failed test (have to check parameters): 1.11.6, 1.11.13
 
@@ -34,3 +35,9 @@ docker run -v cert-data:/cert/:ro,nocopy -it --rm botan-1_11_31-server /cert/rsa
 
 Start server versions >= 1_11_32:
 docker run -v cert-data:/cert/:ro,nocopy -it --rm botan-1_11_32-server /cert/rsa2048cert.pem /cert/rsa2048key.pem --port=4433 --policy=/compat.txt
+
+Start dtls server version 3.2.0:
+docker run -v cert-data:/cert:ro,nocopy -it --rm botan-3_2_0-server /cert/rsa2048cert.pem /cert/rsa2048key.pem --port=4433 --type=udp --policy=/datagam.txt
+
+Start dtls client version 3.2.0:
+docker run -it --rm botan-3_2_0-client 127.0.0.1 --port=4433 --type=udp --policy=/datagram.txt

--- a/images/gnutls/Dockerfile-3_8_0-x
+++ b/images/gnutls/Dockerfile-3_8_0-x
@@ -1,0 +1,53 @@
+FROM alpine-build:3.12 as gnutls-libnettle
+RUN git clone --depth=1 --branch nettle_3.6_release_20200429 https://git.lysator.liu.se/nettle/nettle.git
+WORKDIR /src/nettle
+RUN ./.bootstrap && ./configure --disable-documentation --prefix=/build/
+RUN make && make install
+
+FROM alpine-build:3.12 as gnutls-gnutls
+ARG VERSION
+ENV PKG_CONFIG_PATH=/build/lib/pkgconfig/
+# after 3.6.12 the tag format changed
+RUN git clone --depth=1 --branch gnutls_3_8_${VERSION} https://github.com/gnutls/gnutls || git clone --depth=1 --branch 3.8.${VERSION} https://github.com/gnutls/gnutls
+# RUN git clone --depth 1 --branch 3.8.${VERSION} https://github.com/gnutls/gnutls
+RUN apk add gtk-doc
+RUN apk add guile
+RUN apk add guile-dev
+RUN apk add libtasn1-progs
+RUN wget https://ftp.gnu.org/gnu/autogen/rel5.18.12/autogen-5.18.12.tar.gz
+RUN tar -xzf autogen-5.18.12.tar.gz
+WORKDIR /src/autogen-5.18.12/
+RUN ./configure
+RUN make && make install
+WORKDIR /src/gnutls/
+RUN git submodule update --init --no-fetch
+COPY --from=gnutls-libnettle /build/ /build/
+RUN make autoreconf || ./bootstrap
+RUN ./configure --with-included-libtasn1 --with-included-unistring --disable-maintainer-mode --disable-doc --disable-full-test-suite --disable-cxx --disable-padlock --without-p11-kit --without-tpm --prefix=/build/
+RUN make && make install
+
+FROM entrypoint as gnutls-base
+COPY --from=gnutls-gnutls /lib/ld-musl-x86_64.so.* \
+  /usr/lib/libgmp.so.* \
+  /usr/lib/libintl.so.* \
+  /build/lib/libgnutls.so.* \
+  /build/lib/libnettle.so.* \
+  /build/lib/libhogweed.so.* \
+  /usr/local/lib/libopts.so.* \
+  /lib/libz.so.* /lib/
+
+FROM gnutls-base as gnutls-server
+ARG VERSION
+LABEL "tls_implementation"="gnutls"
+LABEL "tls_implementation_version"="3.8.${VERSION}"
+LABEL "tls_implementation_connectionRole"="server"
+COPY --from=gnutls-gnutls /build/bin/gnutls-serv /bin/
+ENTRYPOINT ["server-entrypoint", "gnutls-serv"]
+
+FROM gnutls-base as gnutls-client
+ARG VERSION
+LABEL "tls_implementation"="gnutls"
+LABEL "tls_implementation_version"="3.8.${VERSION}"
+LABEL "tls_implementation_connectionRole"="client"
+COPY --from=gnutls-gnutls /build/bin/gnutls-cli /bin/
+ENTRYPOINT ["client-entrypoint", "gnutls-cli"]

--- a/images/gnutls/readme
+++ b/images/gnutls/readme
@@ -1,20 +1,23 @@
 ---------------------------
 GNUTLS
 - versions: 
+	3.8.3
 	3.6.0, 3.6.0_1, 3.6.1, 
 	3.5.0, 3.5.1, 3.5.2, 3.5.4, 3.5.5, 3.5.6, 3.5.7, 
 	3.5.8, 3.5.9, 3.5.10, 3.5.11, 3.5.12, 3.5.13, 3.5.14, 3.5.15, 3.5.16, 
 	3.4.0, 3.4.1, 3.4.2, 3.4.3, 3.4.4, 3.4.5, 3.4.6, 3.4.7, 3.4.8, 3.4.9, 3.4.10, 3.4.11, 3.4.12, 3.4.13, 3.4.14, 3.4.15, 3.4.16, 3.4.17, 
 	3.3.0, 3.3.1, 3.3.2, 3.3.3, 3.3.4, 3.3.5, 3.3.6, 3.3.8, 3.3.9, 3.3.10, 3.3.1, 13.3.12, 3.3.13, 3.3.14, 3.3.15, 
 	3.3.16, 3.3.17, 3.3.18, 3.3.19, 3.3.20, 3.3.21, 3.3.22, 3.3.23, 3.3.24, 3.3.25, 3.3.26, 3.3.27, 3.3.28
-- server successfully tested: 3.6.0, 3.6.0_1, 3.6.1, 3.5.16, 3.3.28
-- clients successfully tested: 3.6.0, 3.6.0_1, 3.6.1, 3.5.16, 3.3.28
+- server successfully tested: 3.6.0, 3.6.0_1, 3.6.1, 3.5.16, 3.3.28, 3.8.3
+- clients successfully tested: 3.6.0, 3.6.0_1, 3.6.1, 3.5.16, 3.3.28, 3.8.3
 - server and client versions failed to build (have to check build process): 3.5.7, 3.4.17, 3.3.15, 3.3.28
 
-build server:	docker build -t gnutls-server --target gnutls-server .
-run tls server:	docker run -it --rm -v cert-data:/cert/:ro,nocopy gnutls-server --port=4433 --x509certfile=/cert/rsa2048cert.pem --x509keyfile=/cert/rsa2048key.pem --disable-client-cert
+build server:	 docker build -t gnutls-server --target gnutls-server .
+run tls server:	 docker run -it --rm -v cert-data:/cert/:ro,nocopy gnutls-server --port=4433 --x509certfile=/cert/rsa2048cert.pem --x509keyfile=/cert/rsa2048key.pem --disable-client-cert
+run dtls server: docker run -it --rm gnutls-3_8_3-server -v cert-data:/cert/:ro,nocopy gnutls-server --port=4433 --x509certfile=/cert/rsa2048cert.pem --x509keyfile=/cert/rsa2048key.pem --disable-client-cert --udp
 
-build client:	docker build -t gnutls-client --target gnutls-client .
-run tls client:	docker run -it --rm gnutls-client
+build client:	 docker build -t gnutls-client --target gnutls-client .
+run tls client:	 docker run -it --rm gnutls-client
+run dtls client: docker run -it --rm gnutls-3_8_3-client 127.0.0.1 --port=4433 --udp --insecure
 
 build all supported gnutls versions: ./gnutls.sh

--- a/images/libressl/Dockerfile-3_x
+++ b/images/libressl/Dockerfile-3_x
@@ -1,0 +1,34 @@
+FROM alpine-build:3.6 as libressl
+ARG VERSION
+RUN wget -O libressl.tar.gz https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${VERSION}.tar.gz
+RUN mkdir libressl
+RUN tar -xzf libressl.tar.gz -C libressl --strip-components 1
+WORKDIR libressl
+RUN ./configure &&\
+  make &&\
+  DESTDIR=/build/ make install
+# copy all libs we need
+RUN mkdir /libdeps
+RUN cp $(LD_LIBRARY_PATH="/build/usr/local/lib/" ldd /build/usr/local/bin/openssl | awk '$3=="" {print $1}; $3!="" {print $3}') /libdeps/
+# .la cause problems when compiling other libs with this
+RUN rm /build/usr/local/lib/*.la
+
+FROM entrypoint as libressl-base
+COPY --from=libressl /build/usr/local/ /artifacts/ssllib/
+COPY --from=libressl /libdeps/* /artifacts/ssllib/libdeps/
+COPY --from=libressl /libdeps/* /lib/
+COPY --from=libressl /build/usr/local/bin/openssl /bin/
+
+FROM libressl-base as libressl-server
+ARG VERSION
+LABEL "tls_implementation"="libressl"
+LABEL "tls_implementation_version"="${VERSION}"
+LABEL "tls_implementation_connectionRole"="server"
+ENTRYPOINT ["server-entrypoint", "openssl", "s_server"]
+
+FROM libressl-base as libressl-client
+ARG VERSION
+LABEL "tls_implementation"="libressl"
+LABEL "tls_implementation_version"="${VERSION}"
+LABEL "tls_implementation_connectionRole"="client"
+ENTRYPOINT ["client-entrypoint", "openssl", "s_client"]

--- a/images/libressl/readme
+++ b/images/libressl/readme
@@ -1,6 +1,7 @@
 ---------------------------
 LIBRESSL
 - versions: 
+	3.8.2,
 	2.6.0, 2.6.1, 2.6.2, 2.6.3, 
 	2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.5.4, 2.5.5, 
 	2.4.0 2.4.1 2.4.2 2.4.3 2.4.4 2.4.5,
@@ -8,13 +9,15 @@ LIBRESSL
 	2.2.0, 2.2.1, 2.2.2, 2.2.3, 2.2.4, 2.2.5, 2.2.6, 2.2.7, 2.2.8, 2.2.9,
 	2.1.0, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.1.5, 2.1.6, 2.1.7, 2.1.8, 2.1.9, 2.1.10,
 	2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6
-- server successfully tested: 2.6.3, 2.5.5, 2.4.5, 2.3.10, 2.2.9, 2.1.10, 2.0.6
-- clients successfully tested: 2.6.3, 2.5.5, 2.4.5, 2.3.10, 2.2.9, 2.1.10, 2.0.6
+- server successfully tested: 2.6.3, 2.5.5, 2.4.5, 2.3.10, 2.2.9, 2.1.10, 2.0.6, 3.8.2
+- clients successfully tested: 2.6.3, 2.5.5, 2.4.5, 2.3.10, 2.2.9, 2.1.10, 2.0.6, 3.8.2
 
-build server:   docker build -t libressl-server --target libressl-server .
-run tls server: docker run -it --rm libressl-server
+build server:    docker build -t libressl-server --target libressl-server .
+run tls server:  docker run -it --rm libressl-server
+run dtls server: docker run -it -v cert-data:/cert/:ro,nocopy --rm libressl-3_8_2-server -accept 4433 -cert /cert/rsa2048cert.pem -key /cert/rsa2048key.pem -dtls
 
-build client:   docker build -t libressl-client --target libressl-client .
-run tls client: docker run -it --rm libressl-client
+build client:    docker build -t libressl-client --target libressl-client .
+run tls client:  docker run -it --rm libressl-client
+run dtls client: docker run -it --rm libressl-3_8_2-client -connect 4433 -dtls
 
 build all supported libressl versions: ./libressl.sh

--- a/images/matrixssl/Dockerfile-4_x-dtls
+++ b/images/matrixssl/Dockerfile-4_x-dtls
@@ -1,0 +1,27 @@
+FROM alpine-build:3.12 as matrixssl-base1
+ARG VERSION
+ARG COMMIT
+RUN git clone --depth 1 --branch 4-7-0-open https://github.com/amitv87/matrixssl
+WORKDIR matrixssl
+RUN sed -i 's/define ALLOW_ANON_CONNECTIONS  0/define ALLOW_ANON_CONNECTIONS  1/g' apps/ssl/client.c
+RUN make
+
+FROM entrypoint as matrixssl-base2
+COPY --from=matrixssl-base1 /lib/ld-musl-x86_64.so.* /lib/
+
+FROM matrixssl-base2 as matrixssl-server
+ARG VERSION
+LABEL "tls_implementation"="matrixssl"
+LABEL "tls_implementation_version"="4.${VERSION}"
+LABEL "tls_implementation_connectionRole"="server"
+COPY --from=matrixssl-base1 /src/matrixssl/apps/dtls/dtlsServer /bin/
+COPY --from=matrixssl-base1 /src/matrixssl/testkeys /testkeys
+ENTRYPOINT ["server-entrypoint", "dtlsServer"]
+
+FROM matrixssl-base2 as matrixssl-client
+ARG VERSION
+LABEL "tls_implementation"="matrixssl"
+LABEL "tls_implementation_version"="4.${VERSION}"
+LABEL "tls_implementation_connectionRole"="client"
+COPY --from=matrixssl-base1 /src/matrixssl/apps/dtls/dtlsClient /bin/
+ENTRYPOINT ["client-entrypoint", "dtlsClient"]

--- a/images/matrixssl/readme
+++ b/images/matrixssl/readme
@@ -1,16 +1,19 @@
 ---------------------------
 MATRIXSSL
 - versions: 
+  4.7.0 (dtls),
 	3-9-3, 3-9-1, 3-9-0, 3-8-7b, 3-8-7a, 3-8-7, 3-8-6, 3-8-4, 3-8-3,
 	3-7.2, 3-4.0
-- server successfully tested: -
+- server successfully tested: 4.7.0 (dtls)
 - server failed to test (no default profile found): 3-9-3, 3-7.2
-- clients successfully tested: 3-9-3, 3-7.2
+- clients successfully tested: 3-9-3, 3-7.2, 4.7.0
 
-build server:   docker build -t matrixssl-server --target matrixssl-server .
-run tls server: docker run -it --rm matrixssl-server
+build server:    docker build -t matrixssl-server --target matrixssl-server .
+run tls server:  docker run -it --rm matrixssl-server
+run dtls server: docker run -v cert-data:/cert/:ro,nocopy --rm matrixssl-4_7_0-server -p 4433
 
-build client:   docker build -t matrixssl-client --target matrixssl-client .
-run tls client: docker run -it --rm matrixssl-client
+build client:    docker build -t matrixssl-client --target matrixssl-client .
+run tls client:  docker run -it --rm matrixssl-client
+run dtls client: docker run -it --rmmatrixssl-4_7_0-client -p 4433 --server 127.0.0.1 -no-cert
 
 build all supported matrixssl versions: ./matrixssl.sh

--- a/images/mbedtls/Dockerfile-mbedtls_x3
+++ b/images/mbedtls/Dockerfile-mbedtls_x3
@@ -1,0 +1,29 @@
+FROM alpine-build:3.12 as mbed-base1
+ARG VERSION
+RUN python3 -m ensurepip --upgrade
+RUN python3 -m pip install jsonschema jinja2
+RUN git clone --depth 1 --branch mbedtls-${VERSION} https://github.com/Mbed-TLS/mbedtls mbed
+RUN cd mbed && git submodule update --init --recursive
+RUN sed -i -e 's/ -Werror//g' /src/mbed/CMakeLists.txt
+WORKDIR /build/
+RUN cmake -DCMAKE_BUILD_TYPE=Release /src/mbed &&\
+  make
+
+FROM entrypoint as mbed-base2
+COPY --from=mbed-base1 /lib/ld-musl-x86_64.so.* /lib/
+
+FROM mbed-base2 as mbed-server
+ARG VERSION
+LABEL "tls_implementation"="mbedtls"
+LABEL "tls_implementation_version"="${VERSION}"
+LABEL "tls_implementation_connectionRole"="server"
+COPY --from=mbed-base1 /build/programs/ssl/ssl_server2 /bin/
+ENTRYPOINT ["server-entrypoint", "ssl_server2"]
+
+FROM mbed-base2 as mbed-client
+ARG VERSION
+LABEL "tls_implementation"="mbedtls"
+LABEL "tls_implementation_version"="${VERSION}"
+LABEL "tls_implementation_connectionRole"="client"
+COPY --from=mbed-base1 /build/programs/ssl/ssl_client2 /bin/
+ENTRYPOINT ["client-entrypoint", "ssl_client2"]

--- a/images/mbedtls/readme
+++ b/images/mbedtls/readme
@@ -5,7 +5,7 @@ MBED
 		0.14.2, 0.14.3, 1.0.0, 1.1.0, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.1.6, 1.1.7, 1.1.8,
 		1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.2.5, 1.2.6, 1.2.7, 1.2.8, 1.2.9, 1.2.10, 1.2.11, 1.2.12, 1.2.13, 1.2.14, 1.2.15, 1.2.16, 1.2.17, 1.2.18, 1.2.19, 1.3.0, 1.3.1, 1.3.2, 1.3.3, 1.3.4, 1.3.5, 1.3.6, 1.3.7, 1.3.8, 1.3.9
 	mbedtls:
-		1.3.10, 1.3.11, 1.3.12, 1.3.13, 1.3.14, 1.3.15, 1.3.16, 1.3.17, 1.3.18, 1.3.19, 1.3.20, 1.3.21, 2.0.0, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.1.5, 2.1.6, 2.1.7, 2.1.8, 2.1.9, 2.2.0, 2.2.1, 2.3.0, 2.4.0, 2.4.2, 2.5.1, 2.6.0
+		1.3.10, 1.3.11, 1.3.12, 1.3.13, 1.3.14, 1.3.15, 1.3.16, 1.3.17, 1.3.18, 1.3.19, 1.3.20, 1.3.21, 2.0.0, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.1.5, 2.1.6, 2.1.7, 2.1.8, 2.1.9, 2.2.0, 2.2.1, 2.3.0, 2.4.0, 2.4.2, 2.5.1, 2.6.0, 3.5.1
 - server successfully tested: polarssl-1.1.8, polarssl-1.3.9, mbedtls-2.6.0
 - clients successfully tested: polarssl-1.1.8, polarssl-1.3.9, mbedtls-2.6.0
 
@@ -17,8 +17,14 @@ run tls client: docker run -it --rm mbed-client
 
 build all supported mbed versions: ./mbedtls.sh und ./polarssl.sh
 
-Example for starting a server:
+Example for starting a tls server:
 docker run -v cert-data:/cert/:ro,nocopy -it --rm mbedtls-1.3.11-server crt_file=/cert/rsa2048cert.pem key_file=/cert/rsa2048key.pem server_port=4433
+
+Example for starting a dtls server:
+docker run -v cert-data:/cert/:ro,nocopy -it --rm mbedtls-3_5_1-server crt_file=/cert/rsa2048cert.pem key_file=/cert/rsa2048key.pem server_port=4433 dtls=1
+
+Example for starting a dtls client:
+docker run -it --rm mbedtls-3_5_1-client server_name=127.0.0.1 server_port=4433 dtls=1 auth_mode=optional
 
 The following versions are working:
 - PolarSSL 1.2: >= 1.2.11

--- a/images/openssl/readme
+++ b/images/openssl/readme
@@ -11,16 +11,18 @@ OPENSSL
 	1.0.2, 1.0.2-beta1, 1.0.2-beta2, 1.0.2-beta3,
 	1.0.2a, 1.0.2b, 1.0.2c, 1.0.2d, 1.0.2e, 1.0.2f, 1.0.2g, 1.0.2h, 1.0.2i, 1.0.2j, 1.0.2k, 1.0.2l,	 
 	1.1.0, 1.1.0a, 1.1.0b, 1.1.0c, 1.1.0d, 1.1.0e, 1.1.0f, 1.1.0-pre3,
-	1.1.1-pre2
-- server successfully tested: 0.9.7, 0.9.8, 0.9.8m, 0.9.8m-beta1, 1.0.0, 1.0.0-beta1, 1.0.1, 1.0.1m, 1.0.2, 1.0.2a, 1.1.0
-- clients successfully tested: 0.9.7, 0.9.8, 0.9.8m, 0.9.8m-beta1, 1.0.0, 1.0.0-beta1, 1.0.1, 1.0.1m, 1.0.2, 1.0.2-beta1, 1.1.0
+	1.1.1-pre2,
+  3.2.0
+- server successfully tested: 0.9.7, 0.9.8, 0.9.8m, 0.9.8m-beta1, 1.0.0, 1.0.0-beta1, 1.0.1, 1.0.1m, 1.0.2, 1.0.2a, 1.1.0, 3.2.0
+- clients successfully tested: 0.9.7, 0.9.8, 0.9.8m, 0.9.8m-beta1, 1.0.0, 1.0.0-beta1, 1.0.1, 1.0.1m, 1.0.2, 1.0.2-beta1, 1.1.0, 3.2.0
 
-build server: 	docker build -t openssl-server --target openssl-server .
-run tls server: docker run -it --rm openssl-server
+build server: 	 docker build -t openssl-server --target openssl-server .
+run tls server:  docker run -it --rm openssl-server
+run dtls server: docker run -it -v -cert-data:/cert/:ro,nocopy --rm openssl-3_2_0-server -accept 4433 -key /cert/rsa2048key.pem -cert /cert/rsa2048cert.pem -dtls
 
-build client: 	docker build -t openssl-client --target openssl-client .
-run tls client: docker run -it --rm openssl-client
-
+build client: 	 docker build -t openssl-client --target openssl-client .
+run tls client:  docker run -it --rm openssl-client
+run dtls client: docker run -it --rm openssl-3_2_0-client -connect 127.0.0.1:4433 -dtls
 build all supported openSSL versions: ./openssl-build_all.sh
 
 

--- a/images/wolfssl/Dockerfile-5_x
+++ b/images/wolfssl/Dockerfile-5_x
@@ -1,0 +1,48 @@
+FROM alpine-build:3.6 as wolfssl-base1
+ARG VERSION
+RUN git clone --depth=1 --branch v${VERSION}-stable https://github.com/wolfSSL/wolfssl
+WORKDIR /src/wolfssl/certs
+# update certificates, otherwise lt-client might fail...
+# RUN sed -i 's/-days 1000/-days 100000/g' renewcerts.sh && \
+# sed -i 's/default_days.*/default_days = 100000/g' renewcerts/wolfssl.cnf && \
+# ./renewcerts.sh --override-ntru
+WORKDIR /src/wolfssl
+RUN ./autogen.sh
+RUN ./configure --prefix=/build/ C_FLAGS="-DWOLFSSL_STATIC_RSA" C_EXTRA_FLAGS="-DWOLFSSL_STATIC_RSA" --enable-dtls
+# remove error flags: some wolfssl version do not compile because tab warnings are treated like errors
+RUN mv Makefile tmp && sed "s/-Werror//g" tmp > Makefile
+RUN mv Makefile tmp && sed "s/-Wall//g" tmp > Makefile
+RUN ( make &&\
+      make install)
+WORKDIR /src/wolfssl/examples/server
+# this script is a shell script, which creates (links) the lt-server executable on the fly
+# we need this to copy is later to the execution container
+RUN /src/wolfssl/examples/server/server -h
+RUN /src/wolfssl/examples/client/client -h
+# copy all libs we need
+RUN mkdir /libdeps
+RUN cp $(LD_LIBRARY_PATH="/src/wolfssl/src/.libs/" ldd /src/wolfssl/examples/server/.libs/lt-server | awk '$3=="" {print $1}; $3!="" {print $3}') /libdeps/
+RUN cp $(LD_LIBRARY_PATH="/src/wolfssl/src/.libs/" ldd /src/wolfssl/examples/client/.libs/lt-client | awk '$3=="" {print $1}; $3!="" {print $3}') /libdeps/
+
+FROM entrypoint as wolfssl-base2
+COPY --from=wolfssl-base1 /build/include/ /artifacts/ssllib/include/
+COPY --from=wolfssl-base1 /build/lib/ /artifacts/ssllib/lib/
+COPY --from=wolfssl-base1 /libdeps/* /artifacts/ssllib/libdeps/
+COPY --from=wolfssl-base1 /libdeps/* /lib/
+COPY --from=wolfssl-base1 /src/wolfssl/certs /certs/
+
+FROM wolfssl-base2 as wolfssl-server
+ARG VERSION
+LABEL "tls_implementation"="wolfssl"
+LABEL "tls_implementation_version"="${VERSION}"
+LABEL "tls_implementation_connectionRole"="server"
+COPY --from=wolfssl-base1 /src/wolfssl/examples/server/.libs/lt-server /bin/
+ENTRYPOINT ["server-entrypoint", "lt-server"]
+
+FROM wolfssl-base2 as wolfssl-client
+ARG VERSION
+LABEL "tls_implementation"="wolfssl"
+LABEL "tls_implementation_version"="${VERSION}"
+LABEL "tls_implementation_connectionRole"="client"
+COPY --from=wolfssl-base1 /src/wolfssl/examples/client/.libs/lt-client /bin/
+ENTRYPOINT ["client-entrypoint", "lt-client"]

--- a/images/wolfssl/readme
+++ b/images/wolfssl/readme
@@ -5,14 +5,17 @@ WOLFSSL
 		 2.9.4, 2.9.2, 2.9.1, 2.9.0, 2.8.6, 2.8.5, 2.8.5a, 2.8.4, 2.8.3, 2.8.2, 2.8.0, 2.7.2, 2.7.0, 2.6.2, 2.6.0, 2.5.2b, 2.5.0, 2.4.7, 2.4.6, 2.4.2, 2.4.0, 2.3.0
 	wolfssl:
 		3.12.2-stable, 3.12.0-stable, 3.11.0-stable, 3.10.4, 3.10.3, 3.10.2-stable, 3.10.0a, 3.10.0-stable, 3.9.10b, 3.9.10-stable, 3.9.8, 3.9.6w, 3.9.6, 3.9.1, 3.9.0, 3.7.0, 3.6.9d, 3.6.9c, 3.6.9b, 3.6.9, 3.6.8, 3.6.6, 3.6.2, 3.6.0b, 3.6.0, 3.4.8, 3.4.6, 3.4.2, 3.4.0, 3.3.3,
-		3.3.2, 3.3.0, 3.2.6, 3.2.4, 3.2.0, 3.1.0, 3.0.2, 3.0.0
+		3.3.2, 3.3.0, 3.2.6, 3.2.4, 3.2.0, 3.1.0, 3.0.2, 3.0.0,
+		5.6.6
 - server successfully tested: wolfssl-3.12.2-stable, wolfssl-3.3.2, cyassl-2.9.4
 - clients successfully tested: wolfssl-3.12.2-stable, wolfssl-3.3.2, cyassl-2.9.4
 
-build server:   docker build -t wolfssl-server --target wolfssl-server .
-run tls server: docker run -it --rm wolfssl-server
+build server:    docker build -t wolfssl-server --target wolfssl-server .
+run tls server:  docker run -it --rm wolfssl-server
+run dtls server: docker run -it -v cert-data:/cert/:ro,nocopy --rm wolfssl-5_6_6-server -p 4433 -c /cert/rsa2048cert.pem -k /cert/rsa2048key.pem -u -b
 
-build client:   docker build -t wolfssl-client --target wolfssl-client .
-run tls client: docker run -it --rm wolfssl-client
+build client:    docker build -t wolfssl-client --target wolfssl-client .
+run tls client:  docker run -it --rm wolfssl-client
+run dtls client: docker run -it --rm wolfssl-5_6_6-client -h 127.0.0.1 -p 4433 -u -d
 
 build all supported wolfssl versions: ./wolfssl.sh and ./cyassl.sh


### PR DESCRIPTION
- Add most recent versions for `GnuTLS`, `LibreSSL`, `Mbed-TLS`, `OpenSSL` and `wolfSSL`
- Add explicit files for DTLS for `BotanSSL` and `MatrixSSL`
- Add Alpine-Build 3.19: `BotanSSL` requires from `3.x.x` and upwards `g++ >= 11` which is not available in the current Alpine-Builds (`3.12` has only `g++ 9`)
- Update READMEs for new versions and DTLS support